### PR TITLE
Fix deprecated typing annotations in types.py

### DIFF
--- a/src/pyloadapi/types.py
+++ b/src/pyloadapi/types.py
@@ -25,7 +25,7 @@ of the server responses and available commands.
 
 from dataclasses import asdict, dataclass
 from enum import StrEnum
-from typing import Any, List, Type, TypeVar
+from typing import Any, TypeVar
 
 T = TypeVar("T")
 
@@ -44,7 +44,7 @@ class Response:
     """
 
     @classmethod
-    def from_dict(cls: Type[T], d: dict[Any, Any]) -> T:
+    def from_dict(cls: type[T], d: dict[Any, Any]) -> T:
         """Create an instance of the Response class from a dictionary.
 
         Parameters
@@ -156,7 +156,7 @@ class LoginResponse(Response):
     role: int
     perms: int
     template: str
-    _flashes: List[Any]
+    _flashes: list[Any]
 
 
 class PyLoadCommand(StrEnum):


### PR DESCRIPTION
- Updated import statement in `types.py` to remove unused imports and organize existing ones.
- Revised method signature of `from_dict` in `Response` class to use `type[T]` instead of `Type[T]` to address deprecation warning.
- Updated typing annotation for `_flashes` attribute in `LoginResponse` class from `List[Any]` to `list[Any]` as `List` is deprecated.