### PR TITLE
Fix URLs and update repository links in documentation and configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ You can contribute in many ways:
 
 ### Report Bugs
 
-Report bugs at <https://github.com/tr4nt0r/PyLoadAPI/issues>.
+Report bugs at <https://github.com/tr4nt0r/pyloadapi/issues>.
 
 If you are reporting a bug, please include:
 
@@ -38,7 +38,7 @@ posts, articles, and such.
 ### Submit Feedback
 
 The best way to send feedback is to file an issue at
-<https://github.com/tr4nt0r/PyLoadAPI/issues>.
+<https://github.com/tr4nt0r/pyloadapi/issues>.
 
 If you are proposing a feature:
 
@@ -58,7 +58,7 @@ local development.
 2.  Clone your fork locally:
 
     ``` shell
-    $ git clone git@github.com:tr4nt0r/PyLoadAPI.git
+    $ git clone git@github.com:tr4nt0r/pyloadapi.git
     ```
 
 3.  Install your local copy into a virtualenv. Assuming you have
@@ -105,7 +105,7 @@ Before you submit a pull request, check that it meets these guidelines:
     Put your new functionality into a function with a docstring, and add
     the feature to the list in README.rst.
 3.  The pull request should work for Python 3.11 and 3.12. Check
-    <https://github.com/tr4nt0r/PyLoadAPI/actions/workflows/pytest.yaml>
+    <https://github.com/tr4nt0r/pyloadapi/actions/workflows/pytest.yaml>
     and make sure that the tests pass for all supported Python versions.
 
 ## Tips

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ---
 
-**Documentation**: <a href="https://tr4nt0r.github.io/pyloadapi/" target="_blank">https://tr4nt0r.github.io/pyloadapi/</a>
+**Documentation**: <a href="https://tr4nt0r.github.io/pyloadapi" target="_blank">https://tr4nt0r.github.io/pyloadapi</a>
 
 **Source Code**: <a href="https://github.com/tr4nt0r/pyloadapi" target="_blank">https://github.com/tr4nt0r/pyloadapi</a>
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,19 +19,19 @@ can guide you through the process.
 ## From sources
 
 The sources for PyLoadAPI can be downloaded from the [Github
-repo](https://github.com/tr4nt0r/PyLoadAPI).
+repo](https://github.com/tr4nt0r/pyloadapi).
 
 You can either clone the public repository:
 
 ``` console
-$ git clone git://github.com/tr4nt0r/PyLoadAPI
+$ git clone git://github.com/tr4nt0r/pyloadapi
 ```
 
 Or download the
-[tarball](https://github.com/tr4nt0r/PyLoadAPI/tarball/master):
+[tarball](https://github.com/tr4nt0r/pyloadapi/tarball/master):
 
 ``` console
-$ curl -OJL https://github.com/tr4nt0r/PyLoadAPI/tarball/master
+$ curl -OJL https://github.com/tr4nt0r/pyloadapi/tarball/master
 ```
 
 Once you have a copy of the source, you can install it with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://tr4nt0r.github.io/PyLoadAPI/"
-Source = "https://github.com/tr4nt0r/PyLoadAPI"
+Documentation = "https://tr4nt0r.github.io/pyloadapi"
+Source = "https://github.com/tr4nt0r/pyloadapi"
 
 [tool.hatch.version]
 source = "regex_commit"


### PR DESCRIPTION
- Updated repository links in CONTRIBUTING.md to use lowercase 'pyloadapi' for consistency.
- Corrected documentation URL in README.md to remove the trailing slash.
- Updated GitHub repository links in docs/installation.md to use lowercase 'pyloadapi'.
- Fixed URLs in pyproject.toml to reflect correct documentation and source links.