### PR TITLE
Increase Test Coverage for PyLoadAPI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Fixtures for PyLoadAPI Tests."""
 
-from typing import Any, AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, Generator
+from typing import Any
 
 import aiohttp
 from aioresponses import aioresponses
@@ -24,6 +25,17 @@ TEST_LOGIN_RESPONSE = {
     "perms": 0,
     "template": "default",
     "_flashes": [["message", "Logged in successfully"]],
+}
+
+TEST_STATUS_RESPONSE = {
+    "pause": False,
+    "active": 10,
+    "queue": 5,
+    "total": 15,
+    "speed": 9999999,
+    "download": True,
+    "reconnect": False,
+    "captcha": False,
 }
 
 


### PR DESCRIPTION
Enhanced the testing framework to improve coverage for PyLoadAPI:

- Added new fixture `TEST_STATUS_RESPONSE` to mock status responses.
- Updated imports to use `collections.abc` for `AsyncGenerator` and `Generator`.
- Added parameterized tests in `test_api.py` to cover various API methods including `version`, `get_status`, `pause`, `unpause`, `toggle_pause`, `stop_all_downloads`, `restart_failed`, `toggle_reconnect`, `delete_finished`, `restart`, and `free_space`.
- Implemented a test to validate the `LoginResponse` dataclass methods `from_dict`, `to_dict` and `__getitem__`.